### PR TITLE
fix(mention.directive): add support for special characters

### DIFF
--- a/src/mention/mention.directive.ts
+++ b/src/mention/mention.directive.ts
@@ -150,7 +150,7 @@ export class MentionDirective {
           }
           const mentionWithoutTrigger = mention.substring(1);
           let matches = this.items.filter(
-              e => e.indexOf(mentionWithoutTrigger) !== -1 &&
+              e => e.indexOf(mentionWithoutTrigger) !== -1 ||
                    e.indexOf(mentionWithoutTrigger.toLowerCase()) !== -1
           );
           this.searchList.items = matches;

--- a/src/mention/mention.directive.ts
+++ b/src/mention/mention.directive.ts
@@ -148,8 +148,11 @@ export class MentionDirective {
           if (event.keyCode !== KEY_BACKSPACE) {
             mention += charPressed;
           }
-          let regEx = new RegExp("^" + mention.substring(1), "i");
-          let matches = this.items.filter(e => e.match(regEx) != null);
+          const mentionWithoutTrigger = mention.substring(1);
+          let matches = this.items.filter(
+              e => e.indexOf(mentionWithoutTrigger) !== -1 &&
+                   e.indexOf(mentionWithoutTrigger.toLowerCase()) !== -1
+          );
           this.searchList.items = matches;
           this.searchList.hidden = matches.length == 0 || pos <= this.startPos;
         }


### PR DESCRIPTION
Special characters that would need to be escaped in order to use them as a regex (like `$`), are not usable for searching. Just using a simple `indexOf` works for me.
