### PR TITLE
feat(directive): hide search list on blur

### DIFF
--- a/src/mention/mention.directive.ts
+++ b/src/mention/mention.directive.ts
@@ -25,6 +25,7 @@ const KEY_2 = 50;
   selector: '[mention]',
   host: {
     '(keydown)': 'keyHandler($event)',
+    '(blur)': 'blurHandler()'
   }
 })
 export class MentionDirective {
@@ -155,6 +156,12 @@ export class MentionDirective {
         }
       }
     }
+  }
+
+  blurHandler() {
+    this.stopEvent(event);
+    this.searchList.hidden = true;
+    this.escapePressed = true;
   }
 
   showSearchList(nativeElement: HTMLInputElement) {


### PR DESCRIPTION
Because pressing escape or clicking outside the search list doesn't close it.
